### PR TITLE
Fix creating git_commit.txt on Linux

### DIFF
--- a/UAssetAPI/UAssetAPI.csproj
+++ b/UAssetAPI/UAssetAPI.csproj
@@ -16,7 +16,7 @@
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <Target Name="BeforeBuildMigrated" BeforeTargets="PreBuildEvent">
-    <Exec ContinueOnError="true" Command="git rev-parse --short HEAD &gt; &quot;$(ProjectDir)\git_commit.txt&quot;" />
+    <Exec ContinueOnError="true" Command="git rev-parse --short HEAD &gt; &quot;$(ProjectDir)/git_commit.txt&quot;" />
   </Target>
   <ItemGroup>
     <None Remove="oo2core_9_win64.dll" />


### PR DESCRIPTION
I assume a forward slash should work fine on Windows, but I have not tested. The backslash on Linux ends up creating a file named `\\git_commit.txt` which causes the build to fail.