### PR TITLE
better delegate property support

### DIFF
--- a/UAssetAPI/PropertyTypes/Objects/DelegatePropertyData.cs
+++ b/UAssetAPI/PropertyTypes/Objects/DelegatePropertyData.cs
@@ -1,6 +1,5 @@
 ﻿using Newtonsoft.Json;
 using UAssetAPI.UnrealTypes;
-using UAssetAPI.ExportTypes;
 
 namespace UAssetAPI.PropertyTypes.Objects
 {
@@ -10,10 +9,14 @@ namespace UAssetAPI.PropertyTypes.Objects
     [JsonObject(MemberSerialization.OptIn)]
     public class FDelegate
     {
-        /** Uncertain what this is for; if you find out, please let me know */
+        /// <summary>
+        /// References the main actor export
+        /// </summary>
         [JsonProperty]
         public FPackageIndex Object;
-        /** Uncertain what this is for; if you find out, please let me know */
+        /// <summary>
+        /// The name of the delegate
+        /// </summary>
         [JsonProperty]
         public FName Delegate;
 
@@ -72,7 +75,7 @@ namespace UAssetAPI.PropertyTypes.Objects
 
         public override string ToString()
         {
-           return null;
+            return null;
         }
 
         public override void FromString(string[] d, UAsset asset)
@@ -83,8 +86,8 @@ namespace UAssetAPI.PropertyTypes.Objects
         protected override void HandleCloned(PropertyData res)
         {
             DelegatePropertyData cloningProperty = (DelegatePropertyData)res;
-            
-            cloningProperty.Value = new FDelegate(this.Value.Object, this.Value.Delegate); 
+
+            cloningProperty.Value = new FDelegate(this.Value.Object, this.Value.Delegate);
         }
     }
 }

--- a/UAssetAPI/PropertyTypes/Objects/MulticastDelegatePropertyData.cs
+++ b/UAssetAPI/PropertyTypes/Objects/MulticastDelegatePropertyData.cs
@@ -85,7 +85,7 @@ namespace UAssetAPI.PropertyTypes.Objects
     /// <summary>
     /// Describes a list of functions bound to an Object.
     /// </summary>
-    public class MulticastSparseDelegatePropertyData : PropertyData<FDelegate[]>
+    public class MulticastSparseDelegatePropertyData : MulticastDelegatePropertyData
     {
         public MulticastSparseDelegatePropertyData(FName name) : base(name)
         {
@@ -99,72 +99,13 @@ namespace UAssetAPI.PropertyTypes.Objects
 
         private static readonly FString CurrentPropertyType = new FString("MulticastSparseDelegateProperty");
         public override FString PropertyType { get { return CurrentPropertyType; } }
-
-        public override void Read(AssetBinaryReader reader, FName parentName, bool includeHeader, long leng1, long leng2 = 0)
-        {
-            if (includeHeader)
-            {
-                PropertyGuid = reader.ReadPropertyGuid();
-            }
-
-            int numVals = reader.ReadInt32();
-            Value = new FDelegate[numVals];
-            for (int i = 0; i < numVals; i++)
-            {
-                Value[i] = new FDelegate(reader.XFER_OBJECT_POINTER(), reader.ReadFName());
-            }
-        }
-
-        public override int Write(AssetBinaryWriter writer, bool includeHeader)
-        {
-            if (includeHeader)
-            {
-                writer.WritePropertyGuid(PropertyGuid);
-            }
-
-            writer.Write(Value.Length);
-            for (int i = 0; i < Value.Length; i++)
-            {
-                writer.XFERPTR(Value[i].Object);
-                writer.Write(Value[i].Delegate);
-            }
-            return sizeof(int) + sizeof(int) * 3 * Value.Length;
-        }
-
-        public override string ToString()
-        {
-            string oup = "(";
-            for (int i = 0; i < Value.Length; i++)
-            {
-                oup += "(" + Convert.ToString(Value[i].Object.Index) + ", " + Value[i].Delegate.Value.Value + "), ";
-            }
-            return oup.Substring(0, oup.Length - 2) + ")";
-        }
-
-        public override void FromString(string[] d, UAsset asset)
-        {
-
-        }
-
-        protected override void HandleCloned(PropertyData res)
-        {
-            MulticastSparseDelegatePropertyData cloningProperty = (MulticastSparseDelegatePropertyData)res;
-
-            FDelegate[] newData = new FDelegate[Value.Length];
-            for (int i = 0; i < Value.Length; i++)
-            {
-                newData[i] = new FDelegate(Value[i].Object, (FName)Value[i].Delegate.Clone());
-            }
-
-            cloningProperty.Value = newData;
-        }
     }
 
 
     /// <summary>
     /// Describes a list of functions bound to an Object.
     /// </summary>
-    public class MulticastInlineDelegatePropertyData : PropertyData<FDelegate[]>
+    public class MulticastInlineDelegatePropertyData : MulticastDelegatePropertyData
     {
         public MulticastInlineDelegatePropertyData(FName name) : base(name)
         {
@@ -178,64 +119,5 @@ namespace UAssetAPI.PropertyTypes.Objects
 
         private static readonly FString CurrentPropertyType = new FString("MulticastInlineDelegateProperty");
         public override FString PropertyType { get { return CurrentPropertyType; } }
-
-        public override void Read(AssetBinaryReader reader, FName parentName, bool includeHeader, long leng1, long leng2 = 0)
-        {
-            if (includeHeader)
-            {
-                PropertyGuid = reader.ReadPropertyGuid();
-            }
-
-            int numVals = reader.ReadInt32();
-            Value = new FDelegate[numVals];
-            for (int i = 0; i < numVals; i++)
-            {
-                Value[i] = new FDelegate(reader.XFER_OBJECT_POINTER(), reader.ReadFName());
-            }
-        }
-
-        public override int Write(AssetBinaryWriter writer, bool includeHeader)
-        {
-            if (includeHeader)
-            {
-                writer.WritePropertyGuid(PropertyGuid);
-            }
-
-            writer.Write(Value.Length);
-            for (int i = 0; i < Value.Length; i++)
-            {
-                writer.XFERPTR(Value[i].Object);
-                writer.Write(Value[i].Delegate);
-            }
-            return sizeof(int) + sizeof(int) * 3 * Value.Length;
-        }
-
-        public override string ToString()
-        {
-            string oup = "(";
-            for (int i = 0; i < Value.Length; i++)
-            {
-                oup += "(" + Convert.ToString(Value[i].Object.Index) + ", " + Value[i].Delegate.Value.Value + "), ";
-            }
-            return oup.Substring(0, oup.Length - 2) + ")";
-        }
-
-        public override void FromString(string[] d, UAsset asset)
-        {
-
-        }
-
-        protected override void HandleCloned(PropertyData res)
-        {
-            MulticastInlineDelegatePropertyData cloningProperty = (MulticastInlineDelegatePropertyData)res;
-
-            FDelegate[] newData = new FDelegate[Value.Length];
-            for (int i = 0; i < Value.Length; i++)
-            {
-                newData[i] = new FDelegate(Value[i].Object, (FName)Value[i].Delegate.Clone());
-            }
-
-            cloningProperty.Value = newData;
-        }
     }
 }

--- a/UAssetAPI/PropertyTypes/Objects/MulticastDelegatePropertyData.cs
+++ b/UAssetAPI/PropertyTypes/Objects/MulticastDelegatePropertyData.cs
@@ -1,40 +1,12 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.IO;
+﻿using System;
 using UAssetAPI.UnrealTypes;
-using UAssetAPI.ExportTypes;
 
 namespace UAssetAPI.PropertyTypes.Objects
 {
     /// <summary>
-    /// Describes a function bound to an Object.
-    /// </summary>
-    [JsonObject(MemberSerialization.OptIn)]
-    public class FMulticastDelegate
-    {
-        /** Uncertain what this is for; if you find out, please let me know */
-        [JsonProperty]
-        public int Number;
-        /** Uncertain what this is for; if you find out, please let me know */
-        [JsonProperty]
-        public FName Delegate;
-
-        public FMulticastDelegate(int number, FName @delegate)
-        {
-            Number = number;
-            Delegate = @delegate;
-        }
-
-        public FMulticastDelegate()
-        {
-
-        }
-    }
-
-    /// <summary>
     /// Describes a list of functions bound to an Object.
     /// </summary>
-    public class MulticastDelegatePropertyData : PropertyData<FMulticastDelegate[]>
+    public class MulticastDelegatePropertyData : PropertyData<FDelegate[]>
     {
         public MulticastDelegatePropertyData(FName name) : base(name)
         {
@@ -57,10 +29,10 @@ namespace UAssetAPI.PropertyTypes.Objects
             }
 
             int numVals = reader.ReadInt32();
-            Value = new FMulticastDelegate[numVals];
+            Value = new FDelegate[numVals];
             for (int i = 0; i < numVals; i++)
             {
-                Value[i] = new FMulticastDelegate(reader.ReadInt32(), reader.ReadFName());
+                Value[i] = new FDelegate(reader.XFER_OBJECT_POINTER(), reader.ReadFName());
             }
         }
 
@@ -74,7 +46,7 @@ namespace UAssetAPI.PropertyTypes.Objects
             writer.Write(Value.Length);
             for (int i = 0; i < Value.Length; i++)
             {
-                writer.Write(Value[i].Number);
+                writer.XFERPTR(Value[i].Object);
                 writer.Write(Value[i].Delegate);
             }
             return sizeof(int) + sizeof(int) * 3 * Value.Length;
@@ -85,24 +57,182 @@ namespace UAssetAPI.PropertyTypes.Objects
             string oup = "(";
             for (int i = 0; i < Value.Length; i++)
             {
-                oup += "(" + Convert.ToString(Value[i].Number) + ", " + Value[i].Delegate.Value.Value + "), ";
+                oup += "(" + Convert.ToString(Value[i].Object.Index) + ", " + Value[i].Delegate.Value.Value + "), ";
             }
             return oup.Substring(0, oup.Length - 2) + ")";
         }
 
         public override void FromString(string[] d, UAsset asset)
         {
-            
+
         }
 
         protected override void HandleCloned(PropertyData res)
         {
             MulticastDelegatePropertyData cloningProperty = (MulticastDelegatePropertyData)res;
 
-            FMulticastDelegate[] newData = new FMulticastDelegate[this.Value.Length];
-            for (int i = 0; i < this.Value.Length; i++)
+            FDelegate[] newData = new FDelegate[Value.Length];
+            for (int i = 0; i < Value.Length; i++)
             {
-                newData[i] = new FMulticastDelegate(this.Value[i].Number, (FName)this.Value[i].Delegate.Clone());
+                newData[i] = new FDelegate(Value[i].Object, (FName)Value[i].Delegate.Clone());
+            }
+
+            cloningProperty.Value = newData;
+        }
+    }
+
+
+    /// <summary>
+    /// Describes a list of functions bound to an Object.
+    /// </summary>
+    public class MulticastSparseDelegatePropertyData : PropertyData<FDelegate[]>
+    {
+        public MulticastSparseDelegatePropertyData(FName name) : base(name)
+        {
+
+        }
+
+        public MulticastSparseDelegatePropertyData()
+        {
+
+        }
+
+        private static readonly FString CurrentPropertyType = new FString("MulticastSparseDelegateProperty");
+        public override FString PropertyType { get { return CurrentPropertyType; } }
+
+        public override void Read(AssetBinaryReader reader, FName parentName, bool includeHeader, long leng1, long leng2 = 0)
+        {
+            if (includeHeader)
+            {
+                PropertyGuid = reader.ReadPropertyGuid();
+            }
+
+            int numVals = reader.ReadInt32();
+            Value = new FDelegate[numVals];
+            for (int i = 0; i < numVals; i++)
+            {
+                Value[i] = new FDelegate(reader.XFER_OBJECT_POINTER(), reader.ReadFName());
+            }
+        }
+
+        public override int Write(AssetBinaryWriter writer, bool includeHeader)
+        {
+            if (includeHeader)
+            {
+                writer.WritePropertyGuid(PropertyGuid);
+            }
+
+            writer.Write(Value.Length);
+            for (int i = 0; i < Value.Length; i++)
+            {
+                writer.XFERPTR(Value[i].Object);
+                writer.Write(Value[i].Delegate);
+            }
+            return sizeof(int) + sizeof(int) * 3 * Value.Length;
+        }
+
+        public override string ToString()
+        {
+            string oup = "(";
+            for (int i = 0; i < Value.Length; i++)
+            {
+                oup += "(" + Convert.ToString(Value[i].Object.Index) + ", " + Value[i].Delegate.Value.Value + "), ";
+            }
+            return oup.Substring(0, oup.Length - 2) + ")";
+        }
+
+        public override void FromString(string[] d, UAsset asset)
+        {
+
+        }
+
+        protected override void HandleCloned(PropertyData res)
+        {
+            MulticastSparseDelegatePropertyData cloningProperty = (MulticastSparseDelegatePropertyData)res;
+
+            FDelegate[] newData = new FDelegate[Value.Length];
+            for (int i = 0; i < Value.Length; i++)
+            {
+                newData[i] = new FDelegate(Value[i].Object, (FName)Value[i].Delegate.Clone());
+            }
+
+            cloningProperty.Value = newData;
+        }
+    }
+
+
+    /// <summary>
+    /// Describes a list of functions bound to an Object.
+    /// </summary>
+    public class MulticastInlineDelegatePropertyData : PropertyData<FDelegate[]>
+    {
+        public MulticastInlineDelegatePropertyData(FName name) : base(name)
+        {
+
+        }
+
+        public MulticastInlineDelegatePropertyData()
+        {
+
+        }
+
+        private static readonly FString CurrentPropertyType = new FString("MulticastInlineDelegateProperty");
+        public override FString PropertyType { get { return CurrentPropertyType; } }
+
+        public override void Read(AssetBinaryReader reader, FName parentName, bool includeHeader, long leng1, long leng2 = 0)
+        {
+            if (includeHeader)
+            {
+                PropertyGuid = reader.ReadPropertyGuid();
+            }
+
+            int numVals = reader.ReadInt32();
+            Value = new FDelegate[numVals];
+            for (int i = 0; i < numVals; i++)
+            {
+                Value[i] = new FDelegate(reader.XFER_OBJECT_POINTER(), reader.ReadFName());
+            }
+        }
+
+        public override int Write(AssetBinaryWriter writer, bool includeHeader)
+        {
+            if (includeHeader)
+            {
+                writer.WritePropertyGuid(PropertyGuid);
+            }
+
+            writer.Write(Value.Length);
+            for (int i = 0; i < Value.Length; i++)
+            {
+                writer.XFERPTR(Value[i].Object);
+                writer.Write(Value[i].Delegate);
+            }
+            return sizeof(int) + sizeof(int) * 3 * Value.Length;
+        }
+
+        public override string ToString()
+        {
+            string oup = "(";
+            for (int i = 0; i < Value.Length; i++)
+            {
+                oup += "(" + Convert.ToString(Value[i].Object.Index) + ", " + Value[i].Delegate.Value.Value + "), ";
+            }
+            return oup.Substring(0, oup.Length - 2) + ")";
+        }
+
+        public override void FromString(string[] d, UAsset asset)
+        {
+
+        }
+
+        protected override void HandleCloned(PropertyData res)
+        {
+            MulticastInlineDelegatePropertyData cloningProperty = (MulticastInlineDelegatePropertyData)res;
+
+            FDelegate[] newData = new FDelegate[Value.Length];
+            for (int i = 0; i < Value.Length; i++)
+            {
+                newData[i] = new FDelegate(Value[i].Object, (FName)Value[i].Delegate.Clone());
             }
 
             cloningProperty.Value = newData;


### PR DESCRIPTION
now supports sparse and inline variants and just uses normal FDelegates instead of a FMulticastFDelegate which read the FPackageIndex as an int
unfortunately I couldn't think of another way other than copy pasting to implement the sparse and inline variants and make them detected by reflection