### PR TITLE
fix readstring

### DIFF
--- a/UAssetAPI/Unversioned/UsmapBinaryReader.cs
+++ b/UAssetAPI/Unversioned/UsmapBinaryReader.cs
@@ -74,7 +74,7 @@ namespace UAssetAPI
 
         public string ReadString(int fixedLength = -1)
         {
-            int length = fixedLength > 0 ? fixedLength : this.ReadByte();
+            int length = fixedLength > -1 ? fixedLength : this.ReadByte();
             switch (length)
             {
                 case 0:


### PR DESCRIPTION
This fixed a weird issue when encountering an empty names within an `usmap` file, 1 more byte will be unexpectedly readed, failing the following reading process catastrophly.