### PR TITLE
Fix compile issue on newer(?) dotnet SDK

### DIFF
--- a/UAssetAPI/CRCGenerator.cs
+++ b/UAssetAPI/CRCGenerator.cs
@@ -111,12 +111,12 @@ public static class CRCGenerator
             var next = Math.Min(i + 1, text.Length - 1);
             if (char.IsHighSurrogate(text[i]) && next != i && char.IsLowSurrogate(text[next]))
             {
-                rawDataForCharacter = encoding.GetBytes([text[i], text[++i]]);
+                rawDataForCharacter = encoding.GetBytes( new [] { text[i], text[++i] });
             }
             else
             {
                 char B = !version420 ? ToUpper(text[i]) : ToUpperVersion420(text[i]);
-                rawDataForCharacter = encoding.GetBytes([B]);
+                rawDataForCharacter = encoding.GetBytes(new [] { B });
             }
 
             foreach (byte rawByte in rawDataForCharacter)


### PR DESCRIPTION
Compiling this with .NET SDK 8.0.205 throws some errors about an ambiguous method call:

> 0>CRCGenerator.cs(114,48): Error CS0121 : The call is ambiguous between the following methods or properties: 'Encoding.GetBytes(char[])' and 'Encoding.GetBytes(string)'
0>CRCGenerator.cs(119,48): Error CS0121 : The call is ambiguous between the following methods or properties: 'Encoding.GetBytes(char[])' and 'Encoding.GetBytes(string)'

This is a small fix to allow compiling this again :) Should (hopefully) also work on older SDKs.