### PR TITLE
Adds the option to forego loading the uexp when constructing a UAsset.

### DIFF
--- a/UAssetAPI/AssetBinaryReader.cs
+++ b/UAssetAPI/AssetBinaryReader.cs
@@ -253,10 +253,17 @@ namespace UAssetAPI
     public class AssetBinaryReader : UnrealBinaryReader
     {
         public UnrealPackage Asset;
+        public bool LoadUexp = true;
 
         public AssetBinaryReader(Stream stream, UnrealPackage asset = null) : base(stream)
         {
             Asset = asset;
+        }
+        
+        public AssetBinaryReader(Stream stream, bool inLoadUexp, UnrealPackage asset = null) : base(stream)
+        {
+            Asset = asset;
+            LoadUexp = inLoadUexp;
         }
 
         public virtual Guid? ReadPropertyGuid()

--- a/UAssetAPI/UAsset.cs
+++ b/UAssetAPI/UAsset.cs
@@ -981,7 +981,7 @@ namespace UAssetAPI
             }
 
             BulkData = [];
-            if (BulkDataStartOffset > 0)
+            if (BulkDataStartOffset > 0 && reader.LoadUexp)
             {
                 reader.BaseStream.Seek(BulkDataStartOffset, SeekOrigin.Begin);
                 BulkData = reader.ReadBytes((int)(reader.BaseStream.Length - BulkDataStartOffset));
@@ -1984,6 +1984,26 @@ namespace UAssetAPI
             SetEngineVersion(engineVersion);
 
             Read(PathToReader(path));
+        }
+        
+        /// <summary>
+        /// Reads an asset from disk and initializes a new instance of the <see cref="UAsset"/> class to store its data in memory.
+        /// </summary>
+        /// <param name="path">The path of the asset file on disk that this instance will read from.</param>
+        /// <param name="loadUexp">Whether to load the UEXP file. False only reads the UASSET.</param>
+        /// <param name="engineVersion">The version of the Unreal Engine that will be used to parse this asset. If the asset is versioned, this can be left unspecified.</param>
+        /// <param name="mappings">A valid set of mappings for the game that this asset is from. Not required unless unversioned properties are used.</param>
+        /// <param name="customSerializationFlags">A set of custom serialization flags, which can be used to override certain optional behavior in how UAssetAPI serializes assets.</param>
+        /// <exception cref="UnknownEngineVersionException">Thrown when this is an unversioned asset and <see cref="ObjectVersion"/> is unspecified.</exception>
+        /// <exception cref="FormatException">Throw when the asset cannot be parsed correctly.</exception>
+        public UAsset(string path, bool loadUexp, EngineVersion engineVersion = EngineVersion.UNKNOWN, Usmap mappings = null, CustomSerializationFlags customSerializationFlags = CustomSerializationFlags.None)
+        {
+            this.FilePath = path;
+            this.Mappings = mappings;
+            this.CustomSerializationFlags = customSerializationFlags;
+            SetEngineVersion(engineVersion);
+
+            Read(PathToReader(path, loadUexp));
         }
 
         /// <summary>

--- a/UAssetAPI/UnrealPackage.cs
+++ b/UAssetAPI/UnrealPackage.cs
@@ -315,40 +315,6 @@ namespace UAssetAPI
             if (isSerializationTime) return true;
             return (CustomSerializationFlags & CustomSerializationFlags.NoDummies) == 0;
         }
-
-        /// <summary>
-        /// Creates a MemoryStream from an asset path.
-        /// </summary>
-        /// <param name="p">The path to the input file.</param>
-        /// <returns>A new MemoryStream that stores the binary data of the input file.</returns>
-        public MemoryStream PathToStream(string p)
-        {
-            using (FileStream origStream = File.Open(p, FileMode.Open, FileAccess.Read, FileShare.Read))
-            {
-                MemoryStream completeStream = new MemoryStream();
-                origStream.CopyTo(completeStream);
-                
-                UseSeparateBulkDataFiles = false;
-                try
-                {
-                    var targetFile = Path.ChangeExtension(p, "uexp");
-                    if (File.Exists(targetFile))
-                    {
-                        using (FileStream newStream = File.Open(targetFile, FileMode.Open))
-                        {
-                            completeStream.Seek(0, SeekOrigin.End);
-                            newStream.CopyTo(completeStream);
-                            UseSeparateBulkDataFiles = true;
-                        }
-                    }
-                }
-                catch (FileNotFoundException) { }
-                
-
-                completeStream.Seek(0, SeekOrigin.Begin);
-                return completeStream;
-            }
-        }
         
         /// <summary>
         /// Creates a MemoryStream from an asset path.
@@ -358,11 +324,11 @@ namespace UAssetAPI
         /// <returns>A new MemoryStream that stores the binary data of the input file.</returns>
         public MemoryStream PathToStream(string p, bool loadUEXP = true)
         {
-            using (FileStream origStream = File.Open(p, FileMode.Open, new FileInfo(p).IsReadOnly ? FileAccess.Read : FileAccess.ReadWrite))
+            using (FileStream origStream = File.Open(p, FileMode.Open, FileAccess.Read))
             {
                 MemoryStream completeStream = new MemoryStream();
                 origStream.CopyTo(completeStream);
-                
+
                 if (loadUEXP)
                 {
                     UseSeparateBulkDataFiles = false;
@@ -381,28 +347,18 @@ namespace UAssetAPI
                     }
                     catch (FileNotFoundException) { }
                 }
-                
+
 
                 completeStream.Seek(0, SeekOrigin.Begin);
                 return completeStream;
             }
-        }
-
-        /// <summary>
-        /// Creates a BinaryReader from an asset path.
-        /// </summary>
-        /// <param name="p">The path to the input file.</param>
-        /// <returns>A new BinaryReader that stores the binary data of the input file.</returns>
-        public AssetBinaryReader PathToReader(string p)
-        {
-            return new AssetBinaryReader(PathToStream(p), this);
         }
         
         /// <summary>
         /// Creates a BinaryReader from an asset path.
         /// </summary>
         /// <param name="p">The path to the input file.</param>
-        /// <param name="loadUEXP">Whether to load the UEXP file. False only reads the UASSET.</param>
+        /// <param name="loadUEXP">Whether to load the .uexp file. False only reads the .uasset file.</param>
         /// <returns>A new BinaryReader that stores the binary data of the input file.</returns>
         public AssetBinaryReader PathToReader(string p, bool loadUEXP = true)
         {
@@ -766,7 +722,7 @@ namespace UAssetAPI
                 _internalAssetPath = value;
             }
         }
-        protected void ConvertExportToChildExportAndRead(AssetBinaryReader reader, int i)
+        protected void ConvertExportToChildExportAndRead(AssetBinaryReader reader, int i, bool read = true)
         {
 #pragma warning disable CS0168 // Variable is declared but never used
             try
@@ -789,57 +745,49 @@ namespace UAssetAPI
                 {
                     case "Level":
                         Exports[i] = Exports[i].ConvertToChildExport<LevelExport>();
-                        Exports[i].Read(reader, (int)nextStarting);
                         break;
                     case "Enum":
                     case "UserDefinedEnum":
                         Exports[i] = Exports[i].ConvertToChildExport<EnumExport>();
-                        Exports[i].Read(reader, (int)nextStarting);
                         break;
                     case "Function":
                         Exports[i] = Exports[i].ConvertToChildExport<FunctionExport>();
-                        Exports[i].Read(reader, (int)nextStarting);
                         break;
                     case "UserDefinedStruct":
                         Exports[i] = Exports[i].ConvertToChildExport<UserDefinedStructExport>();
-                        Exports[i].Read(reader, (int)nextStarting);
                         break;
                     default:
                         if (exportClassType.EndsWith("DataTable"))
                         {
                             Exports[i] = Exports[i].ConvertToChildExport<DataTableExport>();
-                            Exports[i].Read(reader, (int)nextStarting);
                         }
                         else if (exportClassType.EndsWith("StringTable"))
                         {
                             Exports[i] = Exports[i].ConvertToChildExport<StringTableExport>();
-                            Exports[i].Read(reader, (int)nextStarting);
                         }
                         else if (exportClassType.EndsWith("BlueprintGeneratedClass"))
                         {
                             Exports[i] = Exports[i].ConvertToChildExport<ClassExport>();
-                            Exports[i].Read(reader, (int)nextStarting);
                         }
                         else if (exportClassType == "ScriptStruct")
                         {
                             Exports[i] = Exports[i].ConvertToChildExport<StructExport>();
-                            Exports[i].Read(reader, (int)nextStarting);
                         }
                         else if (MainSerializer.PropertyTypeRegistry.ContainsKey(exportClassType) || MainSerializer.AdditionalPropertyRegistry.Contains(exportClassType))
                         {
                             Exports[i] = Exports[i].ConvertToChildExport<PropertyExport>();
-                            Exports[i].Read(reader, (int)nextStarting);
                         }
                         else
                         {
                             Exports[i] = Exports[i].ConvertToChildExport<NormalExport>();
-                            Exports[i].Read(reader, (int)nextStarting);
                         }
                         break;
                 }
 
+                if (read) Exports[i].Read(reader, (int)nextStarting);
+
                 // if we got a StructExport, let's modify mappings/MapStructTypeOverride if we can
-                if (Exports[i] is StructExport fetchedStructExp && Exports[i] is not FunctionExport)
+                if (read && Exports[i] is StructExport fetchedStructExp && Exports[i] is not FunctionExport)
                 {
                     // check to see if we can add some new map type overrides
                     if (fetchedStructExp.LoadedProperties != null)
@@ -876,7 +824,7 @@ namespace UAssetAPI
                 }
 
                 // if we got an enum, let's add to mappings enum map if we can
-                if (Exports[i] is EnumExport fetchedEnumExp)
+                if (read && Exports[i] is EnumExport fetchedEnumExp)
                 {
                     string enumName = fetchedEnumExp.ObjectName?.ToString();
                     if (Mappings?.EnumMap != null && enumName != null)
@@ -890,26 +838,29 @@ namespace UAssetAPI
                     }
                 }
 
-                long extrasLen = nextStarting - reader.BaseStream.Position;
-                if (extrasLen < 0)
+                if (read)
                 {
-                    throw new FormatException("Invalid padding at end of export " + (i + 1) + ": " + extrasLen + " bytes");
-                }
-                else
-                {
-                    Exports[i].Extras = reader.ReadBytes((int)extrasLen);
-                }
+                    long extrasLen = nextStarting - reader.BaseStream.Position;
+                    if (extrasLen < 0)
+                    {
+                        throw new FormatException("Invalid padding at end of export " + (i + 1) + ": " + extrasLen + " bytes");
+                    }
+                    else
+                    {
+                        Exports[i].Extras = reader.ReadBytes((int)extrasLen);
+                    }
 
-                Exports[i].alreadySerialized = true;
+                    Exports[i].alreadySerialized = true;
+                }
             }
             catch (Exception ex)
             {
 #if DEBUGVERBOSE
                 Console.WriteLine("\nFailed to parse export " + (i + 1) + ": " + ex.ToString());
 #endif
-                reader.BaseStream.Seek(Exports[i].SerialOffset, SeekOrigin.Begin);
+                if (read) reader.BaseStream.Seek(Exports[i].SerialOffset, SeekOrigin.Begin);
                 Exports[i] = Exports[i].ConvertToChildExport<RawExport>();
-                ((RawExport)Exports[i]).Data = reader.ReadBytes((int)Exports[i].SerialSize);
+                if (read) ((RawExport)Exports[i]).Data = reader.ReadBytes((int)Exports[i].SerialSize);
             }
 #pragma warning restore CS0168 // Variable is declared but never used
         }


### PR DESCRIPTION
This is helpful for scenarios in which you only need information found in the header/uasset and you do not want to pay the memory costs of loading the uexps as well.
