### PR TITLE
Implement MetaData Export support

### DIFF
--- a/UAssetAPI/ExportTypes/MetaDataExport.cs
+++ b/UAssetAPI/ExportTypes/MetaDataExport.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using System.IO;
+using UAssetAPI.UnrealTypes;
+using UAssetAPI.ExportTypes;
+using System;
+using UAssetAPI.CustomVersions;
+using System.Reflection.PortableExecutable;
+
+namespace UAssetAPI.ExportTypes
+{
+    public class MetaDataExport : NormalExport
+    {
+        public List<(int, Dictionary<FName, FString>)> ObjectMetaData;
+        public Dictionary<FName, FString> RootMetaData;
+
+        public MetaDataExport(Export super) : base(super)
+        {
+
+        }
+
+        public MetaDataExport(UAsset asset, byte[] extras) : base(asset, extras)
+        {
+
+        }
+
+        public MetaDataExport()
+        {
+
+        }
+        public override void Read(AssetBinaryReader reader, int nextStarting)
+        {
+            base.Read(reader, nextStarting);
+
+            {
+                ObjectMetaData = [];
+                var objectMetaDataMapCount = reader.ReadInt32();
+                for (var i = 0; i < objectMetaDataMapCount; i++)
+                {
+                    var import = reader.ReadInt32();
+                    var metaDataCount = reader.ReadInt32();
+                    var metaData = new Dictionary<FName, FString>();
+                    for (var j = 0; j < metaDataCount; j++)
+                    {
+                        var key = reader.ReadFName();
+                        var value = reader.ReadFString();
+                        metaData.Add(key, value);
+                    }
+                    ObjectMetaData.Add((import, metaData));
+                }
+            }
+
+            if (reader.Asset.GetCustomVersion<FEditorObjectVersion>() >= FEditorObjectVersion.RootMetaDataSupport)
+            {
+                RootMetaData = [];
+                var rootMetaDataMapCount = reader.ReadInt32();
+                for (var i = 0; i < rootMetaDataMapCount; i++)
+                {
+                    var key = reader.ReadFName();
+                    var value = reader.ReadFString();
+                    RootMetaData.Add(key, value);
+                }
+            }
+        }
+
+        public override void Write(AssetBinaryWriter writer)
+        {
+            base.Write(writer);
+
+            writer.Write(ObjectMetaData.Count);
+            foreach ((var import, var metaData) in ObjectMetaData)
+            {
+                writer.Write(import);
+                writer.Write(metaData.Count);
+                foreach ((var key, var value) in metaData)
+                {
+                    writer.Write(key);
+                    writer.Write(value);
+                }
+            }
+
+            if (writer.Asset.GetCustomVersion<FEditorObjectVersion>() >= FEditorObjectVersion.RootMetaDataSupport)
+            {
+                writer.Write(RootMetaData.Count);
+                foreach ((var key, var value) in RootMetaData)
+                {
+                    writer.Write(key);
+                    writer.Write(value);
+                }
+            }
+        }
+    }
+}

--- a/UAssetAPI/UnrealPackage.cs
+++ b/UAssetAPI/UnrealPackage.cs
@@ -756,6 +756,9 @@ namespace UAssetAPI
                     case "UserDefinedStruct":
                         Exports[i] = Exports[i].ConvertToChildExport<UserDefinedStructExport>();
                         break;
+                    case "MetaData":
+                        Exports[i] = Exports[i].ConvertToChildExport<MetaDataExport>();
+                        break;
                     default:
                         if (exportClassType.EndsWith("DataTable"))
                         {


### PR DESCRIPTION
This PR is a continuation of work on the support of uncooked assets. It adds a support for the MetaData export, which has data about some UObjects and, since FEditorObjectVersion::RootMetaDataSupport, data about the package itself.

![image](https://github.com/user-attachments/assets/12452b92-e6b3-4e4d-a72b-f98d7461c584)

The only part I'm not sure about is ObjectMetaDataMap, it's supposed to be a map ([`TMap< FWeakObjectPtr, TMap<FName, FString> >`](https://github.com/EpicGames/UnrealEngine/blob/4.27.2-release/Engine/Source/Runtime/CoreUObject/Private/UObject/Obj.cpp)), but the asset `TestActorBP.uasset` has two maps that belong to an object by the index `0`, thus losing some data. So I made it a list, and now it passes the binary equality tests.