### PR TITLE
Fix Compiler Warnings and Improve FSoftObjectPath Equality

### DIFF
--- a/UAssetAPI.Tests/AssetUnitTests.cs
+++ b/UAssetAPI.Tests/AssetUnitTests.cs
@@ -77,6 +77,81 @@ namespace UAssetAPI.Tests
         }
 
         /// <summary>
+        /// Tests <see cref="FSoftObjectPath"/> equality functionality including IEquatable implementation.
+        /// </summary>
+        [TestMethod]
+        public void TestFSoftObjectPathEquality()
+        {
+            // Create a dummy asset for FName construction
+            var dummyAsset = new UAsset(Path.Combine("TestAssets", "TestManyAssets", "Astroneer", "Augment_BroadBrush.uasset"), EngineVersion.VER_UE4_23);
+            
+            // Create test instances
+            var packageName1 = new FName(dummyAsset, "TestPackage");
+            var assetName1 = new FName(dummyAsset, "TestAsset");
+            var subPath1 = new FString("SubPath1");
+            
+            var packageName2 = new FName(dummyAsset, "TestPackage");
+            var assetName2 = new FName(dummyAsset, "TestAsset");
+            var subPath2 = new FString("SubPath1");
+            
+            var packageName3 = new FName(dummyAsset, "DifferentPackage");
+            var assetName3 = new FName(dummyAsset, "DifferentAsset");
+            var subPath3 = new FString("SubPath2");
+
+            var path1 = new FSoftObjectPath(packageName1, assetName1, subPath1);
+            var path2 = new FSoftObjectPath(packageName2, assetName2, subPath2); // Same values
+            var path3 = new FSoftObjectPath(packageName3, assetName3, subPath3); // Different values
+            var path4 = new FSoftObjectPath(packageName1, assetName1, null); // Null subpath
+
+            // Test IEquatable<FSoftObjectPath>.Equals
+            Assert.IsTrue(path1.Equals(path2), "Equal paths should return true with typed Equals");
+            Assert.IsTrue(path2.Equals(path1), "Equal paths should return true with typed Equals (symmetry)");
+            Assert.IsFalse(path1.Equals(path3), "Different paths should return false with typed Equals");
+            Assert.IsFalse(path1.Equals(path4), "Paths with different subpaths should return false with typed Equals");
+
+            // Test object.Equals
+            Assert.IsTrue(path1.Equals((object)path2), "Equal paths should return true with object Equals");
+            Assert.IsFalse(path1.Equals((object)path3), "Different paths should return false with object Equals");
+            Assert.IsFalse(path1.Equals(null), "Path should not equal null");
+            Assert.IsFalse(path1.Equals("string"), "Path should not equal different type");
+
+            // Test == operator
+            Assert.IsTrue(path1 == path2, "Equal paths should return true with == operator");
+            Assert.IsFalse(path1 == path3, "Different paths should return false with == operator");
+
+            // Test != operator
+            Assert.IsFalse(path1 != path2, "Equal paths should return false with != operator");
+            Assert.IsTrue(path1 != path3, "Different paths should return true with != operator");
+
+            // Test GetHashCode consistency
+            Assert.IsTrue(path1.GetHashCode() == path2.GetHashCode(), "Equal paths should have equal hash codes");
+            
+            // Test with null values
+            var pathWithNullPackage = new FSoftObjectPath(new FTopLevelAssetPath(null, assetName1), subPath1);
+            var pathWithNullAsset = new FSoftObjectPath(new FTopLevelAssetPath(packageName1, null), subPath1);
+            var pathWithNullSubPath = new FSoftObjectPath(packageName1, assetName1, null);
+            
+            Assert.IsFalse(path1.Equals(pathWithNullPackage), "Paths with null package should not equal non-null");
+            Assert.IsFalse(path1.Equals(pathWithNullAsset), "Paths with null asset should not equal non-null");
+            Assert.IsFalse(path1.Equals(pathWithNullSubPath), "Paths with null subpath should not equal non-null");
+            
+            // Test null equality
+            var pathAllNull = new FSoftObjectPath(new FTopLevelAssetPath(null, null), null);
+            var pathAllNull2 = new FSoftObjectPath(new FTopLevelAssetPath(null, null), null);
+            Assert.IsTrue(pathAllNull.Equals(pathAllNull2), "Paths with all null values should be equal");
+            
+            // Test partial equality scenarios
+            var pathSamePackageAsset = new FSoftObjectPath(new FTopLevelAssetPath(packageName1, assetName1), subPath3);
+            Assert.IsFalse(path1.Equals(pathSamePackageAsset), "Paths with same package/asset but different subpath should not be equal");
+            
+            var pathSamePackageSubPath = new FSoftObjectPath(new FTopLevelAssetPath(packageName1, assetName3), subPath1);
+            Assert.IsFalse(path1.Equals(pathSamePackageSubPath), "Paths with same package/subpath but different asset should not be equal");
+            
+            var pathSameAssetSubPath = new FSoftObjectPath(new FTopLevelAssetPath(packageName3, assetName1), subPath1);
+            Assert.IsFalse(path1.Equals(pathSameAssetSubPath), "Paths with same asset/subpath but different package should not be equal");
+        }
+
+        /// <summary>
         /// Tests <see cref="FName.ToString"/> and <see cref="FName.FromString"/>.
         /// </summary>
         [TestMethod]

--- a/UAssetAPI/CustomVersions/CustomVersions.cs
+++ b/UAssetAPI/CustomVersions/CustomVersions.cs
@@ -624,7 +624,7 @@ namespace UAssetAPI.CustomVersions
         [Introduced(EngineVersion.VER_UE5_5)]
         LandscapeTargetLayersInLandscapeActor,
 
-        /// <summary>Fix to get full name of templated type ( Tarray > TArray<Float> for example )</summary>
+        /// <summary>Fix to get full name of templated type ( Tarray > TArray{Float} for example )</summary>
         [Introduced(EngineVersion.VER_UE5_5)]
         DataflowTemplatedTypeFix,
 
@@ -688,8 +688,10 @@ namespace UAssetAPI.CustomVersions
         [Introduced(EngineVersion.VER_UE5_5)]
         PCGApplyOnActorNodeMoveTargetActorEdgeToInput,
 
-        /// <summary>Deprecation of the bPlaying flag on FTimeline struct types in favor of a better</summary>
-        /// <summary>PlayingStateTracker type to improve replication reliability </summary>
+        /// <summary>
+        /// Deprecation of the bPlaying flag on FTimeline struct types in favor of a better
+        /// PlayingStateTracker type to improve replication reliability
+        /// </summary>
         [Introduced(EngineVersion.VER_UE5_5)]
         TimelinePlayingStateTrackerDeprecation,
 

--- a/UAssetAPI/PropertyTypes/Objects/SoftObjectPropertyData.cs
+++ b/UAssetAPI/PropertyTypes/Objects/SoftObjectPropertyData.cs
@@ -72,7 +72,7 @@ public struct FTopLevelAssetPath
 /// <summary>
 /// A reference variable to another object which may be null, and may become valid or invalid at any point.
 /// </summary>
-public struct FSoftObjectPath
+public struct FSoftObjectPath : IEquatable<FSoftObjectPath>
 {
     /// <summary>
     /// Asset path, patch to a top level object in a package. This is /package/path.assetname/
@@ -164,6 +164,23 @@ public struct FSoftObjectPath
     public static bool operator !=(FSoftObjectPath lhs, FSoftObjectPath rhs)
     {
         return !lhs.Equals(rhs);
+    }
+
+    public bool Equals(FSoftObjectPath other)
+    {
+        return AssetPath.PackageName == other.AssetPath.PackageName &&
+               AssetPath.AssetName == other.AssetPath.AssetName &&
+               SubPathString == other.SubPathString;
+    }
+
+    public override bool Equals(object obj)
+    {
+        return obj is FSoftObjectPath other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(AssetPath.PackageName, AssetPath.AssetName, SubPathString);
     }
 }
 


### PR DESCRIPTION
Fixes compiler warnings and improves FSoftObjectPath equality performance.

- Fixed XML documentation warnings in CustomVersions.cs:
- Merged duplicate &lt;summary&gt; tags in TimelinePlayingStateTrackerDeprecation
- Used curly braces {Float} instead of &lt;Float&gt; in DataflowTemplatedTypeFix to follow .NET conventions
- Fixed equality operator warnings in FSoftObjectPath:
  - Implemented IEquatable&lt;FSoftObjectPath&gt; for better performance (avoids boxing)
  - Added proper Equals and GetHashCode overrides
  - Added comprehensive tests for FSoftObjectPath equality covering all scenarios

Resolves CS0660/CS0661 warnings and improves performance through proper equality implementation.