### PR TITLE
Implement FunctionExport serialization and fix a crash in AncestryInfo

### DIFF
--- a/UAssetAPI/ExportTypes/FunctionExport.cs
+++ b/UAssetAPI/ExportTypes/FunctionExport.cs
@@ -1,6 +1,7 @@
 using System.IO;
-using UAssetAPI.UnrealTypes;
+using System.Reflection.PortableExecutable;
 using UAssetAPI.ExportTypes;
+using UAssetAPI.UnrealTypes;
 
 namespace UAssetAPI.ExportTypes
 {
@@ -10,6 +11,10 @@ namespace UAssetAPI.ExportTypes
     public class FunctionExport : StructExport
     {
         public EFunctionFlags FunctionFlags;
+		public int RepOffset;
+		public FPackageIndex EventGraphFunction;
+		public int EventGraphCallOffset;
+
         public FunctionExport(Export super) : base(super)
         {
             Asset = super.Asset;
@@ -30,14 +35,43 @@ namespace UAssetAPI.ExportTypes
         {
             base.Read(reader, nextStarting);
             FunctionFlags = (EFunctionFlags)reader.ReadUInt32();
-            // TODO
+            
+			if (FunctionFlags.HasFlag(EFunctionFlags.FUNC_Net))
+			{
+				RepOffset = reader.ReadInt32();
+			}
+			else
+			{
+				RepOffset = 0;
+			}
+
+			if (reader.Asset.ObjectVersion >= ObjectVersion.VER_UE4_SERIALIZE_BLUEPRINT_EVENTGRAPH_FASTCALLS_IN_UFUNCTION)
+			{
+				EventGraphFunction = new(reader.ReadInt32());
+				EventGraphCallOffset = reader.ReadInt32();
+			}
+			else
+			{
+				EventGraphFunction = null;
+				EventGraphCallOffset = 0;
+			}
         }
 
         public override void Write(AssetBinaryWriter writer)
         {
             base.Write(writer);
             writer.Write((uint)FunctionFlags);
-            // TODO
-        }
+
+			if (FunctionFlags.HasFlag(EFunctionFlags.FUNC_Net))
+			{
+				writer.Write(RepOffset);
+			}
+
+			if (writer.Asset.ObjectVersion >= ObjectVersion.VER_UE4_SERIALIZE_BLUEPRINT_EVENTGRAPH_FASTCALLS_IN_UFUNCTION)
+			{
+				writer.Write(EventGraphFunction.Index);
+				writer.Write(EventGraphCallOffset);
+			}
+		}
     }
 }

--- a/UAssetAPI/ExportTypes/FunctionExport.cs
+++ b/UAssetAPI/ExportTypes/FunctionExport.cs
@@ -11,7 +11,7 @@ namespace UAssetAPI.ExportTypes
     public class FunctionExport : StructExport
     {
         public EFunctionFlags FunctionFlags;
-		public int RepOffset;
+		public short RepOffset;
 		public FPackageIndex EventGraphFunction;
 		public int EventGraphCallOffset;
 
@@ -38,7 +38,7 @@ namespace UAssetAPI.ExportTypes
             
 			if (FunctionFlags.HasFlag(EFunctionFlags.FUNC_Net))
 			{
-				RepOffset = reader.ReadInt32();
+				RepOffset = reader.ReadInt16();
 			}
 			else
 			{

--- a/UAssetAPI/PropertyTypes/Objects/PropertyData.cs
+++ b/UAssetAPI/PropertyTypes/Objects/PropertyData.cs
@@ -96,7 +96,7 @@ namespace UAssetAPI.PropertyTypes.Objects
 
         public void SetAsParent(FName dad, FName modulePath = null)
         {
-            if (dad != null) Ancestors.Add(string.IsNullOrEmpty(modulePath?.Value?.Value) ? dad : FName.DefineDummy(null, modulePath.Value.Value + "." + dad.Value.Value));
+            if (dad?.Value != null) Ancestors.Add(string.IsNullOrEmpty(modulePath?.Value?.Value) ? dad : FName.DefineDummy(null, modulePath.Value.Value + "." + dad.Value.Value));
         }
     }
 


### PR DESCRIPTION
* `FunctionExport` had TODOs in its serialization code that should be completed by these changes. For reference, I looked at `UFunction::Serialize` in Class.cpp. The code is the same in UE 4.27 and UE 5.6. I have only tested with UE 5.6 assets.
* While creating test assets using UE 5.6, I managed to create one that triggered a crash in `AncestryInfo.SetAsParent` where the parameter `dad` had its `Value` property set to `null` which triggered a `NullReferenceException` when accessing `dad.Value.Value`.

Existing unit tests all passed.