### PR TITLE
Support new export type: AssetImportData

### DIFF
--- a/UAssetAPI/ExportTypes/AssetImportDataExport.cs
+++ b/UAssetAPI/ExportTypes/AssetImportDataExport.cs
@@ -1,0 +1,38 @@
+using UAssetAPI.UnrealTypes;
+
+namespace UAssetAPI.ExportTypes
+{
+    public class AssetImportDataExport : NormalExport
+    {
+        public FString Json;
+
+        public AssetImportDataExport(Export super) : base(super)
+        {
+
+        }
+
+        public AssetImportDataExport(UAsset asset, byte[] extras) : base(asset, extras)
+        {
+
+        }
+
+        public AssetImportDataExport()
+        {
+
+        }
+
+        public override void Read(AssetBinaryReader reader, int nextStarting)
+        {
+            Json = reader.ReadFString();
+
+            base.Read(reader, nextStarting);
+        }
+
+        public override void Write(AssetBinaryWriter writer)
+        {
+            writer.Write(Json);
+
+            base.Write(writer);
+        }
+    }
+}

--- a/UAssetAPI/UAsset.cs
+++ b/UAssetAPI/UAsset.cs
@@ -913,6 +913,9 @@ namespace UAssetAPI
                     case "MetaData":
                         Exports[i] = Exports[i].ConvertToChildExport<MetaDataExport>();
                         break;
+                    case "AssetImportData":
+                        Exports[i] = Exports[i].ConvertToChildExport<AssetImportDataExport>();
+                        break;
                     default:
                         if (exportClassType.EndsWith("DataTable"))
                         {


### PR DESCRIPTION
See AssetImportData.cpp in Unreal Engine code.

Just a new export type. AssetImportData overrides `Serialize` so that it requires specific processing. Verified to pass all test cases. No LLM generated code used.