### PR TITLE
Preserve read metadata bytes on rewrite

### DIFF
--- a/UAssetAPI/UAsset.cs
+++ b/UAssetAPI/UAsset.cs
@@ -1497,6 +1497,9 @@ namespace UAssetAPI
         /// <summary>Location into the file on disk for the MetaData data</summary>
         internal int MetaDataOffset;
 
+        /// <summary>Raw bytes of the MetaData section (between MetaDataOffset and the next section). Preserved during roundtrip.</summary>
+        internal byte[] MetaDataBytes;
+
         /// <summary>Number of exports contained in this package</summary>
         internal int ExportCount = 0;
 
@@ -1973,6 +1976,13 @@ namespace UAssetAPI
                     var textData = new FGatherableTextData { NamespaceName = namespaceName, SourceData = sourceData, SourceSiteContexts = contexts};
                     GatherableTextData.Add(textData);
                 }
+            }
+
+            // MetaData (build dependency data, UE5.4+)
+            if (MetaDataOffset > 0 && ImportOffset > MetaDataOffset)
+            {
+                reader.BaseStream.Seek(MetaDataOffset, SeekOrigin.Begin);
+                MetaDataBytes = reader.ReadBytes(ImportOffset - MetaDataOffset);
             }
 
             // Imports
@@ -2628,6 +2638,17 @@ namespace UAssetAPI
                             writer.Write(context.KeyMetaData);
                         }
                     }
+                }
+
+                // MetaData (build dependency data, UE5.4+)
+                if (MetaDataBytes != null && MetaDataBytes.Length > 0)
+                {
+                    this.MetaDataOffset = (int)writer.BaseStream.Position;
+                    writer.Write(MetaDataBytes);
+                }
+                else if (ObjectVersionUE5 >= ObjectVersionUE5.METADATA_SERIALIZATION_OFFSET)
+                {
+                    this.MetaDataOffset = (int)writer.BaseStream.Position;
                 }
 
                 // Imports


### PR DESCRIPTION
Fixes loss of MetaData section when roundtripping UE5.4+ assets

Steps to reproduce:
1. Open any .uasset created by UE5.4+ (ObjectVersionUE5 >= METADATA_SERIALIZATION_OFFSET)
2. Roundtrip it: new UAsset(path, engineVersion).Write(outputPath)
3. Compare file sizes — output is smaller (e.g. -53 bytes for attached test Material based on Epic tutorial [M_Screen_Damage.zip](https://github.com/user-attachments/files/26293361/M_Screen_Damage.zip))
4. Open the roundtripped file in Unreal Editor — it fails to load

Root cause:
UAsset.ReadHeader() reads MetaDataOffset (introduced in UE5.4), but the corresponding
bytes are never read or preserved. During write:
- The original MetaDataOffset is written back into the header
- No MetaData section is emitted

This causes:
- The MetaData section to be dropped
- File size to shrink
- MetaDataOffset to point to an invalid location

Observed impact:
For a UE5.7 Material asset, this removes 53 bytes of build dependency hash data.
The resulting file is rejected by Unreal Editor.

What the MetaData section contains:
Raw bytes between MetaDataOffset and ImportOffset.
In UE5.7 this includes package build dependency metadata (hash strings).
This format is currently not parsed by UAssetAPI.

Fix:
Preserve the MetaData section as raw bytes (passthrough):

- Add field: byte[] MetaDataBytes
- Read: capture bytes between MetaDataOffset and ImportOffset
- Write: emit MetaDataBytes before Imports and update MetaDataOffset

This preserves correctness without introducing format-specific parsing.
Future work could deserialize this section if needed.