### PR TITLE
Fix deserialization error by making FPackageIndex IComparable

### DIFF
--- a/UAssetAPI/UnrealTypes/FPackageIndex.cs
+++ b/UAssetAPI/UnrealTypes/FPackageIndex.cs
@@ -15,7 +15,7 @@ namespace UAssetAPI.UnrealTypes;
 /// The actual array index will be (-FPackageIndex - 1)
 /// </summary>
 [JsonConverter(typeof(FPackageIndexJsonConverter))]
-public class FPackageIndex
+public class FPackageIndex : IComparable
 {
     /// <summary>
     /// Values greater than zero indicate that this is an index into the ExportMap.
@@ -117,6 +117,12 @@ public class FPackageIndex
     {
         if (!(obj is FPackageIndex comparingPackageIndex)) return false;
         return comparingPackageIndex.Index == this.Index;
+    }
+
+    public int CompareTo(object obj)
+    {
+        if (!(obj is FPackageIndex comparingPackageIndex)) return 0;
+        return Index.CompareTo(comparingPackageIndex.Index);
     }
 
     public static bool operator <(FPackageIndex first, FPackageIndex second)


### PR DESCRIPTION
# Pull Request

## Description

I encountered an error while de-serializing an UAsset file leading to an exception.

This was caused by an entry being added to `UAsset.SearchableNames`, while FPackageIndex is not IComparable.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I am currently testing on a proprietary asset, but I guess that any `.uasset` that exposes at least 2 packages with searchable names should reproduce.