### PR TITLE
Fix UE 5.7 version mapping

### DIFF
--- a/UAssetAPI/UnrealTypes/UE4VersionToObjectVersion.cs
+++ b/UAssetAPI/UnrealTypes/UE4VersionToObjectVersion.cs
@@ -52,7 +52,7 @@ namespace UAssetAPI.UnrealTypes
         VER_UE5_4 = 1012,
         VER_UE5_5 = 1013,
         VER_UE5_6 = 1017,
-        VER_UE5_7 = 1018,
+        VER_UE5_7 = 1017,
         VER_UE5_8 = 1018,
     }
 }


### PR DESCRIPTION
I noticed that the latest commit on master branch did not work with UE 5.7 games, but the commit corresponding to release 1.1.0 did. I found that reverting the change made to UAssetAPI/UnrealTypes/UE4VersionToObjectVersion.cs in this commit:

https://github.com/atenfyr/UAssetAPI/commit/e6730b282682b73772ad0adabbf21fed51fb1253

fixed the issue. An example stack trace:

Error:
System.InvalidOperationException: Invalid FString length: 1920300133
   at UAssetAPI.UnrealBinaryReader.ReadFString() in /home/markov/coding/dotnet/UAssetAPI/UAssetAPI/AssetBinaryReader.cs:line 114
   at UAssetAPI.FEngineVersion..ctor(UnrealBinaryReader reader) in /home/markov/coding/dotnet/UAssetAPI/UAssetAPI/UAsset.cs:line 174
   at UAssetAPI.UAsset.ReadHeader(AssetBinaryReader reader) in /home/markov/coding/dotnet/UAssetAPI/UAssetAPI/UAsset.cs:line 1891
   at UAssetAPI.UAsset.Read(AssetBinaryReader reader, Int32[] manualSkips, Int32[] forceReads) in /home/markov/coding/dotnet/UAssetAPI/UAssetAPI/UAsset.cs:line 1975
   at UAssetAPI.UAsset..ctor(String path, EngineVersion engineVersion, Usmap mappings, CustomSerializationFlags customSerializationFlags, GameSpecificOverride gsOverride) in /home/markov/coding/dotnet/UAssetAPI/UAssetAPI/UAsset.cs:line 3370
   
This is the first pull request I've ever submitted, so I apologise if the quality is not up to par. But at least, I believe the problem to have been clearly identified, and a workable solution presented.